### PR TITLE
Update to support and logical_nparens on 5.37.7 and later

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Changelog for re-engine-GNU
 
-0.024 2017-08-01T12:49:20
+0.024 2017-08-01T12:49:20Z
  [Jean-Damien Durand <jeandamiendurand@free.fr>]
  - Use SvCANCOW() - fixes #5
 

--- a/GNU.xs
+++ b/GNU.xs
@@ -218,10 +218,10 @@ REGEXP * GNU_comp(pTHX_ SV * const pattern, const U32 flags)
       a_syntax = av_fetch(av, 0, 1);
 
       if (a_pattern == NULL || get_type(aTHX_ (SV *)*a_pattern) != SCALAR) {
-        croak("%s: array ref must have a scalar as second element, got %d", logHeader, get_type(aTHX_ (SV *)a_pattern));
+        croak("%s: array ref must have a scalar as second element, got %" IVdf, logHeader, get_type(aTHX_ (SV *)a_pattern));
       }
       if (a_syntax == NULL || get_type(aTHX_ (SV *)*a_syntax) != SCALAR) {
-        croak("%s: array ref must have a scalar as first element, got %d", logHeader, get_type(aTHX_ (SV *)a_syntax));
+        croak("%s: array ref must have a scalar as first element, got %" IVdf, logHeader, get_type(aTHX_ (SV *)a_syntax));
       }
 
       sv_pattern = newSVsv(*a_pattern);
@@ -448,6 +448,9 @@ REGEXP * GNU_comp(pTHX_ SV * const pattern, const U32 flags)
     REGEXP_LASTPAREN_SET(r, 0);
     REGEXP_LASTCLOSEPAREN_SET(r, 0);
     REGEXP_NPARENS_SET(r, (U32)ri->regex.re_nsub); /* cast from size_t */
+#ifdef REGEXP_LOGICAL_NPARENS_SET
+    REGEXP_LOGICAL_NPARENS_SET(r, (U32)ri->regex.re_nsub);
+#endif
     if (isDebug) {
       fprintf(stderr, "%s: ... %d () detected\n", logHeader, (int) ri->regex.re_nsub);
     }
@@ -539,26 +542,26 @@ GNU_exec_set_capture_string(pTHX_ REGEXP * const rx,
                 " subbeg=%p"
 #endif
 #if REGEXP_SUBLEN_CAN
-                " sublen=%d"
+                " sublen=%" IVdf
 #endif
 #if REGEXP_SUBOFFSET_CAN
-                " suboffset=%d"
+                " suboffset=%" IVdf
 #endif
 #if REGEXP_SUBCOFFSET_CAN
-                " subcoffset=%d"
+                " subcoffset=%" IVdf
 #endif
                 "\n", logHeader
 #if REGEXP_SUBBEG_CAN
                 , REGEXP_SUBBEG_GET(r)
 #endif
 #if REGEXP_SUBLEN_CAN
-                , REGEXP_SUBLEN_GET(r)
+                , (IV)REGEXP_SUBLEN_GET(r)
 #endif
 #if REGEXP_SUBOFFSET_CAN
-                , REGEXP_SUBOFFSET_GET(r)
+                , (IV)REGEXP_SUBOFFSET_GET(r)
 #endif
 #if REGEXP_SUBCOFFSET_CAN
-                , REGEXP_SUBCOFFSET_GET(r)
+                , (IV)REGEXP_SUBCOFFSET_GET(r)
 #endif
                 );
       }
@@ -646,26 +649,26 @@ GNU_exec_set_capture_string(pTHX_ REGEXP * const rx,
                   " subbeg=%p"
 #endif
 #if REGEXP_SUBLEN_CAN
-                  " sublen=%d"
+                  " sublen=%" IVdf
 #endif
 #if REGEXP_SUBOFFSET_CAN
-                  " suboffset=%d"
+                  " suboffset=%" IVdf
 #endif
 #if REGEXP_SUBCOFFSET_CAN
-                  " subcoffset=%d"
+                  " subcoffset=%" IVdf
 #endif
                   "\n", logHeader
 #if REGEXP_SUBBEG_CAN
                   , REGEXP_SUBBEG_GET(r)
 #endif
 #if REGEXP_SUBLEN_CAN
-                  , REGEXP_SUBLEN_GET(r)
+                  , (IV)REGEXP_SUBLEN_GET(r)
 #endif
 #if REGEXP_SUBOFFSET_CAN
-                  , REGEXP_SUBOFFSET_GET(r)
+                  , (IV)REGEXP_SUBOFFSET_GET(r)
 #endif
 #if REGEXP_SUBCOFFSET_CAN
-                  , REGEXP_SUBCOFFSET_GET(r)
+                  , (IV)REGEXP_SUBCOFFSET_GET(r)
 #endif
                   );
         }
@@ -699,7 +702,8 @@ GNU_exec_set_capture_string(pTHX_ REGEXP * const rx,
                                                 (U8*)(strbeg + REGEXP_SUBOFFSET_GET(r))));
       }
       if (isDebug) {
-        fprintf(stderr, "%s: ... suboffset=%d and utf8target=%d => subcoffset=%d\n", logHeader, REGEXP_SUBOFFSET_GET(r), (int) utf8_target, REGEXP_SUBCOFFSET_GET(r));
+        fprintf(stderr, "%s: ... suboffset=%" IVdf " and utf8target=%" IVdf " => subcoffset=%" IVdf "\n", 
+            logHeader, (IV)REGEXP_SUBOFFSET_GET(r), (IV)utf8_target, (IV)REGEXP_SUBCOFFSET_GET(r));
       }
 #endif /* REGEXP_SUBCOFFSET_CAN && REGEXP_SUBOFFSET_CAN */
     }

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Jean-Damien Durand <jeandamiendurand@free.fr>"
    ],
    "dynamic_config" : 1,
-   "generated_by" : "Dist::Zilla version 6.010, CPAN::Meta::Converter version 2.150010",
+   "generated_by" : "Dist::Zilla version 6.029, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
@@ -41,6 +41,7 @@
             "Test::CPAN::Changes" : "0.19",
             "Test::CPAN::Meta" : "0",
             "Test::CPAN::Meta::JSON" : "0.16",
+            "Test::DistManifest" : "0",
             "Test::EOL" : "0",
             "Test::Kwalitee" : "1.21",
             "Test::MinimumVersion" : "0",
@@ -77,7 +78,6 @@
             "IPC::Open3" : "0",
             "Test::More" : "0",
             "Thread" : "0",
-            "blib" : "1.01",
             "perl" : "5.010000"
          }
       }
@@ -85,7 +85,7 @@
    "provides" : {
       "re::engine::GNU" : {
          "file" : "lib/re/engine/GNU.pm",
-         "version" : "0.024"
+         "version" : "0.025"
       }
    },
    "release_status" : "stable",
@@ -101,8 +101,10 @@
          "web" : "https://github.com/jddurand/re-engine-gnu"
       }
    },
-   "version" : "0.024",
-   "x_authority" : "cpan:JDDPAUSE",
-   "x_serialization_backend" : "Cpanel::JSON::XS version 3.0237"
+   "version" : "0.025",
+   "x_authority" : "cpan:YVES",
+   "x_generated_by_perl" : "v5.37.8",
+   "x_serialization_backend" : "Cpanel::JSON::XS version 4.32",
+   "x_spdx_expression" : "Artistic-1.0-Perl OR GPL-1.0-or-later"
 }
 

--- a/README.GNU.txt
+++ b/README.GNU.txt
@@ -1,4 +1,4 @@
-The following files come fomr gnulib version 20140202:
+The following files come from gnulib version 20140202:
 
 regcomp.c regex.c regexec.c regex.h regex_internal.c regex_internal.h
 

--- a/README.pod
+++ b/README.pod
@@ -8,7 +8,7 @@ re::engine::GNU - GNU Regular Expression Engine
 
 =head1 VERSION
 
-version 0.024
+version 0.025
 
 =head1 SYNOPSIS
 

--- a/etc/config_REGEXP.pl
+++ b/etc/config_REGEXP.pl
@@ -22,7 +22,7 @@ sub do_config_REGEXP {
     print STDERR "... regexp structure configuration\n";
     print STDERR "... ------------------------------\n";
     $ac->check_cc;
-    my @regexpMembers = qw/engine mother_re paren_names extflags minlen minlenret gofs substrs nparens intflags pprivate lastparen lastcloseparen swap offs subbeg saved_copy sublen suboffset subcoffset maxlen pre_prefix compflags prelen precomp wrapped wraplen seen_evals refcnt/;
+    my @regexpMembers = qw/engine mother_re paren_names extflags minlen minlenret gofs substrs nparens intflags pprivate lastparen lastcloseparen logical_nparens swap offs subbeg saved_copy sublen suboffset subcoffset maxlen pre_prefix compflags prelen precomp wrapped wraplen seen_evals refcnt/;
     foreach (@regexpMembers) {
         $ac->check_member("regexp.$_", { prologue => "#include \"EXTERN.h\"
 #include \"perl.h\"


### PR DESCRIPTION
This should fix this module under Perl 5.37.7 and later.

See https://github.com/Perl/perl5/issues/20710

You may want to consider whether Dist::Zilla is appropriate for this module. It took me over an hour to get the Dist::Zilla deps installed, and 3 minutes to fix the bug. :-( And you seem to be missing Dist::Zilla related dependencies, i had to manually install some, and some of them dont install cleanly on blead perl (i need to investigate why Test::Vars breaks.)

I suggest you try building the latest blead perl and then trying to install the deps and build your module. It will show some issues... I had to manually install:

Pod::Weaver::PluginBundle::RJBS
Config::AutoConf

and i had to force install Test::Vars to get Dist::Zilla::Plugin::Test::UnusedVars to install.

Anyway, if you like Dist::Zilla then so be it, but it would be much friendlier to people like me if you included a Makefile.PL that can be used as a fallback.

